### PR TITLE
Filters for Triggers and update multiple widgets per item

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -18,7 +18,7 @@ while True:
                 gb.monitoring(webmondata,piece)
                 gb.push(piece)
             if kind == "Triggers":
-                triggers = ZabbixData().getunacktriggers()
+                triggers = ZabbixData().getunacktriggers(piece)
                 gb.triggerlist(triggers,piece)
                 gb.push(piece)
             if kind == "Other":

--- a/configs.py
+++ b/configs.py
@@ -6,3 +6,41 @@ zabbixapipasswd = 'your zabbix passwd'
 notriggersmessage = 'Good job, infra! Nothing is triggered on Zabbix :-)'
 
 runinterval = 600
+
+####################
+#
+#  Sample config
+#
+pieces = [
+#           { 'type': 'Zabbix Item',
+#             'kind': 'Item',
+#             'name': 'Sample Name',
+#             'zid': 12345,
+#             'widgit_key': '123456-12345678-1234-1234-1234-123456789012',
+#             'mintrigger': 1,
+#             'maxtrigger': 50,
+#             'percenttrigger': 40,
+#             'colortrigger': '012345',
+#             'unit': '%',
+#           },
+
+#           {
+#             'type': 'Zabbix Item',
+#             'kind': 'Monitoring',
+#             'httpcodezid': 28985,
+#             'httpexpectedcode': 200,
+#             'httptimezid': 28984,
+#             'httplasterrorzid': 28982,
+#             'name': 'psafe.com',
+#             'widgit_key': [ '123456-12345678-1234-1234-1234-123456789012',
+#                             '123456-12345678-1234-1234-1234-123456789012' ],
+#           },
+
+#           {
+#             'type': 'Zabbix Item',
+#             'kind': 'Triggers',
+#             'name': 'Unack issues',
+#             'widget_key': '109909-6601885f-f14d-4a93-a3d0-3a2aab269348',
+#             'filter': { 'priority': 1 },
+#           },
+         ]

--- a/geckoboard.py
+++ b/geckoboard.py
@@ -135,7 +135,11 @@ class Geckoboard:
 
     def push(self, widgetdefinitions):
         wk = widgetdefinitions['widget_key']
-        response = requests.post('https://push.geckoboard.com/v1/send/' + wk,
+        if type(wk) is not list:
+            wk = [ wk ]
+
+        for key in wk:
+            response = requests.post('https://push.geckoboard.com/v1/send/' + key,
                                  data=json.dumps(self.widgetdata),
                                  headers=self.headers)
         print response.text

--- a/zabbixdata.py
+++ b/zabbixdata.py
@@ -84,7 +84,13 @@ class ZabbixData:
         print history
         return history
 
-    def getunacktriggers(self):
+    def getunacktriggers(self,item):
+        if 'filter' in item:
+            if 'value' not in item['filter']:
+                item['filter']['value'] = 1
+        else:
+            item['filter'] = { 'value':1 }
+
         triggers = self.zapi.trigger.get(only_true=1,
                                          skipDependent=1,
                                          monitored=1,
@@ -95,6 +101,6 @@ class ZabbixData:
                                          withLastEventUnacknowledged=1,
                                          sortfield='priority',
                                          sortorder='DESC',
-                                         filter={'value': 1},
+                                         filter=item['filter'],
                                         )
         return triggers


### PR DESCRIPTION
Here are a couple of tweeks we've made to allow for filtering on triggers (namely selecting priority so we can have a Geckoboard list of only Disasters/High/Etc) and to allow updating of multiple Geckoboard widgets for each request to Zabbix.
